### PR TITLE
Introduces a new reservation listing page for central admin users

### DIFF
--- a/src/services/urls/central_admin.py
+++ b/src/services/urls/central_admin.py
@@ -74,7 +74,7 @@ from services.views import central_admin
 from django.shortcuts import get_object_or_404
 from django.http import FileResponse
 from services.models import ExportedFile
-from services.views.central_admin import GenerateStudentPassView, StudentPassFileDownloadView
+from services.views.central_admin import GenerateStudentPassView, StudentPassFileDownloadView,reservation_list
 
 app_name = 'central_admin'
 
@@ -164,4 +164,6 @@ urlpatterns = [
      path('student-pass/download/<slug:slug>/', StudentPassFileDownloadView.as_view(), name='student_pass_file_download'),
      
      path('registrations/<slug:registration_slug>/bus-records/export-pdf/', central_admin.BusRecordExportPDFView.as_view(), name='bus_record_export_pdf'),
+
+     path('reservations/',reservation_list,name='reservation'),
 ]

--- a/src/services/urls/central_admin.py
+++ b/src/services/urls/central_admin.py
@@ -74,7 +74,7 @@ from services.views import central_admin
 from django.shortcuts import get_object_or_404
 from django.http import FileResponse
 from services.models import ExportedFile
-from services.views.central_admin import GenerateStudentPassView, StudentPassFileDownloadView,reservation_list
+from services.views.central_admin import GenerateStudentPassView, StudentPassFileDownloadView, ReservationListView
 
 app_name = 'central_admin'
 
@@ -165,5 +165,5 @@ urlpatterns = [
      
      path('registrations/<slug:registration_slug>/bus-records/export-pdf/', central_admin.BusRecordExportPDFView.as_view(), name='bus_record_export_pdf'),
 
-     path('reservations/',reservation_list,name='reservation'),
+     path('reservations/', ReservationListView.as_view(), name='reservation'),
 ]

--- a/src/services/views/central_admin.py
+++ b/src/services/views/central_admin.py
@@ -2647,4 +2647,5 @@ class BusRecordExportPDFView(LoginRequiredMixin, CentralAdminOnlyAccessMixin, Vi
             filename=f"bus_records_{registration.slug}.pdf",
         )
 
-
+def  reservation_list(request):
+    return render(request,"central_admin/reservation_list.html")

--- a/src/services/views/central_admin.py
+++ b/src/services/views/central_admin.py
@@ -2647,5 +2647,17 @@ class BusRecordExportPDFView(LoginRequiredMixin, CentralAdminOnlyAccessMixin, Vi
             filename=f"bus_records_{registration.slug}.pdf",
         )
 
-def  reservation_list(request):
-    return render(request,"central_admin/reservation_list.html")
+
+class ReservationListView(LoginRequiredMixin, CentralAdminOnlyAccessMixin, TemplateView):
+    """
+    ReservationListView displays the list of reservations for central admin users.
+    
+    This view inherits from:
+        - LoginRequiredMixin: Ensures that the user is authenticated.
+        - CentralAdminOnlyAccessMixin: Ensures that the user has central admin access.
+        - TemplateView: Renders a template with the given context.
+    
+    Attributes:
+        template_name (str): The template to render for this view.
+    """
+    template_name = "central_admin/reservation_list.html"

--- a/src/templates/central_admin/reservation_list.html
+++ b/src/templates/central_admin/reservation_list.html
@@ -1,11 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-</head>
-<body>
+{% extends 'base.html' %}
+
+
+{% block content %}
     <h1>Reservation List Page</h1>
-</body>
-</html>
+{% endblock content %}

--- a/src/templates/central_admin/reservation_list.html
+++ b/src/templates/central_admin/reservation_list.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Reservation List Page</h1>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a new reservation listing page for central admin users. The main changes include the addition of a new view, URL route, and template to support displaying the reservation list.

### Reservation List Feature

* Added `ReservationListView` to `src/services/views/central_admin.py`, providing a central admin-only page for viewing reservations. This view uses `LoginRequiredMixin`, `CentralAdminOnlyAccessMixin`, and renders the `reservation_list.html` template.
* Registered a new URL route in `src/services/urls/central_admin.py` for `/reservations/`, mapped to the new `ReservationListView`.
* Imported `ReservationListView` in `src/services/urls/central_admin.py` to enable routing.
* Added a basic template `src/templates/central_admin/reservation_list.html` for the reservation list page, extending `base.html` and displaying a placeholder header.